### PR TITLE
fix: Corrige erro no teste de visualização da página home

### DIFF
--- a/django_project/tests/views/test_post.py
+++ b/django_project/tests/views/test_post.py
@@ -16,6 +16,6 @@ def test_post_view(client):
     response = client.get(url)
     
     # Verifica se o código de status da resposta é 200 (OK) 
-    # e se a pagina tem como conteúdo Hello Word
+    # e se a pagina tem o conteúdo textual "Welcome to my awesome Blog"
     assert response.status_code == 200
-    assert response.content == b'Hello World'
+    assert b'Welcome to my awesome Blog' in response.content


### PR DESCRIPTION
Correção do teste de visualização da página principal. 
O teste estava falhando devido a uma asserção incorreta no conteúdo esperado. A visualização estava correta, mas o teste não verificava o conteúdo de forma adequada. A asserção foi ajustada para validar corretamente o conteúdo HTML retornado pela página.